### PR TITLE
fix: Corrigindo endereço frontend handbook para a versão 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Follow a list with free _and open-source_ books about front-end.
 ### Front-end
 
 - [Adaptive Web Design](https://adaptivewebdesign.info/1st-edition/) _([Aaron Gustafson](https://www.aaron-gustafson.com/))_
-- [Front-End Developer Handbook](https://www.gitbook.com/book/frontendmasters/front-end-handbook-2017/) _(Front-end Masters)_
+- [Front-End Developer Handbook 2018](https://frontendmasters.com/books/front-end-handbook/2018/) _(Front-end Masters)_
 - [Workflow Front-end](https://www.gitbook.com/book/tapmorales/workflow-front-end/) _([Daniel Tapias](https://github.com/tapmorales))_ :brazil:
 
 ### HTML


### PR DESCRIPTION
Fix url to frontend handbook 2018